### PR TITLE
Idea  for Multiple Profiles in Backend Docker image

### DIFF
--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,14 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/habits
+spring.datasource.username=habits
+spring.datasource.password=habits
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.data.rest.basePath=/data
+spring.flyway.enabled=true
+spring.flyway.user=habits
+spring.flyway.password=habits
+spring.flyway.schemas=public
+spring.flyway.url=jdbc:postgresql://localhost:5432/habits
+# update / create --> No need to write SQL ourselves
+# spring.jpa.properties.javax.persistence.schema-generation.create-source=metadata
+# spring.jpa.properties.javax.persistence.schema-generation.scripts.action=update
+# spring.jpa.properties.javax.persistence.schema-generation.scripts.create-target=update.sql

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,4 +1,5 @@
 spring.h2.console.enabled=true
+spring.h2.console.settings.web-allow-others=true
 spring.h2.console.path=/h2-console
 spring.datasource.url=jdbc:h2:mem:testdb
 spring.datasource.username = sa


### PR DESCRIPTION
Hi Guys,

The getting started documentation was pretty good, however when I wanted to run the backend docker image standalone, without being in the context of a docker-compose, it wasn't very usable because it's hardwired to a database at location //postgress.  (perhaps there's a nice workaround)

Therefore I propose the possibility of having multiple spring-boot profiles.   In this way we could start the  backend in one of three ways:
- production (default) which expects to find database at //postgres
- local which expects to find database at //localhost
- test which uses an H2 inmemory database

examples:
> docker run -e "SPRING_PROFILES_ACTIVE=test" habits-backend:local
or
> mvn spring-boot:run -Dspring-boot.run.profiles=local


This is just a prototype of the idea, and very low-priority.  I imagine you might have better suggestions.

NOTE: I don't edit the application.properties file when running the app from my IDE.  I just set the profile in the run configuration.

See:
https://www.baeldung.com/spring-boot-docker-start-with-profile
